### PR TITLE
Add path delimiter

### DIFF
--- a/udatamodule.pas
+++ b/udatamodule.pas
@@ -82,7 +82,7 @@ end;
 
 function Tdm.getfilePath: string;
 begin
-  result := ExpandFileName(Config.GetValue('Files/Path','.'));
+  result := IncludeTrailingPathDelimiter(ExpandFileName(Config.GetValue('Files/Path','.')));
 end;
 
 function Tdm.getAutoSave: boolean;

--- a/usettings.pas
+++ b/usettings.pas
@@ -70,7 +70,7 @@ end;
 
 procedure TfSettings.OKButtonClick(Sender: TObject);
 begin
- dm.FilePath:= DirectoryEdit1.Directory;
+ dm.FilePath:= IncludeTrailingPathDelimiter(DirectoryEdit1.Directory);
  dm.SaveConfig;
  Close;
 end;


### PR DESCRIPTION
To fix the bug where the program saves a file named _bintodo.txt_. Tested under Linux.